### PR TITLE
Fix typo in the usage configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export default {
     {
       use: '@zefman/gridsome-source-instagram',
       options: {
-        username: 'zefman' // Instagram username
+        username: 'zefman', // Instagram username
         typeName: 'InstagramPhoto' // The GraphQL type you want the photos to be added under. Defaults to InstagramPhoto
       }
     }


### PR DESCRIPTION
If a setting example is copied and pasted, a syntax error occurs.
Added a comma after the username property.